### PR TITLE
Embed DrawingML shapes into slides

### DIFF
--- a/src/svg2pptx.py
+++ b/src/svg2pptx.py
@@ -7,14 +7,17 @@ with proper DrawingML vector graphics integration.
 """
 
 import os
+import re
 import sys
 from pathlib import Path
+
 from pptx import Presentation
-from pptx.util import Inches, Emu
 from pptx.enum.shapes import MSO_SHAPE_TYPE
-from pptx.oxml import parse_xml
-from pptx.oxml.ns import nsdecls, qn
+from pptx.oxml.ns import qn
+from pptx.util import Inches
+
 from .svg2drawingml import SVGToDrawingMLConverter
+
 import tempfile
 import zipfile
 from lxml import etree as ET
@@ -82,30 +85,124 @@ class SVGToPowerPointConverter:
     
     def _add_drawingml_to_slide(self, slide, drawingml_shapes: str):
         """Add DrawingML shapes to slide using XML manipulation."""
-        # This is a simplified approach - in practice, we'd need to
-        # properly integrate with python-pptx's XML structure
-        
-        # For now, let's add a placeholder that shows we have the DrawingML
-        textbox = slide.shapes.add_textbox(
-            Inches(0.5), Inches(0.5), Inches(9), Inches(6.5)
+
+        if not drawingml_shapes or not drawingml_shapes.strip():
+            return
+
+        drawingml_shapes = drawingml_shapes.strip()
+
+        sp_tree = slide.shapes._spTree
+        nsmap = {"p": "http://schemas.openxmlformats.org/presentationml/2006/main"}
+
+        # Collect existing shape IDs and names to avoid collisions on insert.
+        existing_ids = set()
+        existing_names = set()
+        for cNvPr in sp_tree.xpath(".//p:cNvPr", namespaces=nsmap):
+            id_attr = cNvPr.get("id")
+            try:
+                existing_ids.add(int(id_attr))
+            except (TypeError, ValueError):
+                pass
+            name_attr = cNvPr.get("name")
+            if name_attr:
+                existing_names.add(name_attr)
+
+        next_id = (max(existing_ids) + 1) if existing_ids else 1
+
+        # Determine which namespace prefixes are used so that we can declare them
+        # on a temporary root wrapper element for parsing.
+        prefix_pattern = re.compile(r"([A-Za-z_][A-Za-z0-9_\-\.]*):[A-Za-z_]")
+        detected_prefixes = set(prefix_pattern.findall(drawingml_shapes))
+
+        namespace_map = {
+            "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+            "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+            "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+            "a14": "http://schemas.microsoft.com/office/drawing/2010/main",
+            "a15": "http://schemas.microsoft.com/office/drawing/2012/main",
+            "a16": "http://schemas.microsoft.com/office/drawing/2014/main",
+            "p14": "http://schemas.microsoft.com/office/powerpoint/2010/main",
+            "p15": "http://schemas.microsoft.com/office/powerpoint/2012/main",
+            "p16": "http://schemas.microsoft.com/office/powerpoint/2016/main",
+            "p17": "http://schemas.microsoft.com/office/powerpoint/2019/main",
+            "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
+            "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",
+            "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
+            "dgm": "http://schemas.openxmlformats.org/drawingml/2006/diagram",
+            "lc": "http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas",
+            "o": "urn:schemas-microsoft-com:office:office",
+            "v": "urn:schemas-microsoft-com:vml",
+            "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+            "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+            "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
+            "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",
+            "wne": "http://schemas.microsoft.com/office/word/2006/wordml",
+            "xdr": "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing",
+        }
+
+        # Always include the core namespaces expected by DrawingML.
+        detected_prefixes.update({"a", "p", "r"})
+        namespace_attrs = " ".join(
+            f"xmlns:{prefix}=\"{namespace_map[prefix]}\""
+            for prefix in sorted(detected_prefixes)
+            if prefix in namespace_map
         )
-        
-        # Count the shapes
-        shape_count = drawingml_shapes.count('<p:sp>')
-        line_count = drawingml_shapes.count('<p:cxnSp>')
-        total_shapes = shape_count + line_count
-        
-        textbox.text = f"""SVG converted to DrawingML!
-        
-Found {total_shapes} vector shapes:
-- {shape_count} filled shapes
-- {line_count} lines/connectors
 
-DrawingML XML generated:
-{len(drawingml_shapes)} characters
+        wrapper_xml = f"<root {namespace_attrs}>{drawingml_shapes}</root>"
+        try:
+            wrapper = ET.fromstring(wrapper_xml)
+        except ET.XMLSyntaxError as exc:
+            raise ValueError("Invalid DrawingML content provided for insertion") from exc
 
-This is a proof-of-concept. Next step: integrate
-DrawingML XML directly into slide structure."""
+        ext_lst = sp_tree.find(qn('p:extLst'))
+        insert_index = len(sp_tree)
+        if ext_lst is not None:
+            insert_index = list(sp_tree).index(ext_lst)
+
+        for element in list(wrapper):
+            if not isinstance(element.tag, str):
+                continue
+
+            for cNvPr in element.xpath(".//p:cNvPr", namespaces=nsmap):
+                id_attr = cNvPr.get("id")
+                assign_new_id = False
+                try:
+                    id_value = int(id_attr)
+                except (TypeError, ValueError):
+                    assign_new_id = True
+                    id_value = None
+                else:
+                    if id_value in existing_ids:
+                        assign_new_id = True
+
+                if assign_new_id:
+                    id_value = next_id
+                    next_id += 1
+                    cNvPr.set("id", str(id_value))
+                else:
+                    if id_value >= next_id:
+                        next_id = id_value + 1
+
+                existing_ids.add(id_value)
+
+                name_attr = cNvPr.get("name")
+                if name_attr and name_attr not in existing_names:
+                    existing_names.add(name_attr)
+                else:
+                    base_name = name_attr or "SVG Shape"
+                    suffix = 2 if name_attr else 1
+                    candidate = base_name if not name_attr else f"{base_name} {suffix}"
+                    while candidate in existing_names:
+                        suffix += 1
+                        candidate = f"{base_name} {suffix}"
+                    cNvPr.set("name", candidate)
+                    existing_names.add(candidate)
+
+            if ext_lst is not None:
+                sp_tree.insert(insert_index, element)
+                insert_index += 1
+            else:
+                sp_tree.append(element)
     
     def batch_convert(self, svg_directory: str, output_directory: str = None):
         """


### PR DESCRIPTION
## Summary
- replace the placeholder textbox with logic that injects DrawingML directly into the slide shape tree
- ensure unique shape ids/names, respect existing extLst ordering, and tolerate common namespaces when parsing snippets
- add a regression test that verifies DrawingML snippets survive a PPTX round-trip as real auto-shapes

## Testing
- python -m py_compile src/svg2pptx.py tests/unit/test_svg2pptx.py
- pytest tests/unit/test_svg2pptx.py::TestSVGToPowerPointConverter::test_drawingml_shapes_round_trip -q *(fails: missing required plugins and proxy blocks installing them)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c757ad883208be2a6a19e8054c5