### PR TITLE
Fix conversion service validation for NumPy resolver

### DIFF
--- a/src/services/conversion_services.py
+++ b/src/services/conversion_services.py
@@ -240,7 +240,19 @@ class ConversionServices:
             self.unit_converter.to_emu("10px")
             self.color_parser.parse("#000000")
             self.transform_parser.parse("translate(10,20)")
-            self.viewport_resolver.parse_viewbox("0 0 100 100")
+
+            viewboxes = self.viewport_resolver.parse_viewbox_strings(["0 0 100 100"])
+            try:
+                first_viewbox = viewboxes[0]
+            except (IndexError, TypeError):
+                return False
+
+            if (
+                first_viewbox is None
+                or first_viewbox["width"] <= 0
+                or first_viewbox["height"] <= 0
+            ):
+                return False
 
             return True
 


### PR DESCRIPTION
## Summary
- update `ConversionServices.validate_services` to call the resolver's `parse_viewbox_strings` helper
- ensure the returned viewBox data is valid before reporting success

## Testing
- `pytest tests/integration/test_dependency_injection_integration.py::TestEndToEndServiceInjection::test_conversion_services_full_integration` *(fails: missing required pytest plugins in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c80edcc8320a6277e1dd2682bcc