### PR TITLE
Inject services into NumPy shape converters

### DIFF
--- a/src/converters/shapes/__init__.py
+++ b/src/converters/shapes/__init__.py
@@ -45,8 +45,7 @@ class RectangleConverter(NumPyShapeConverter):
 
     def __init__(self, services=None, optimization_level=2):
         """Initialize with services (dependency injection) and optimization level."""
-        super().__init__(optimization_level)
-        self.services = services
+        super().__init__(services=services, optimization_level=optimization_level)
 
     def can_convert(self, element):
         return self.get_element_tag(element) == 'rect'
@@ -57,8 +56,7 @@ class CircleConverter(NumPyShapeConverter):
 
     def __init__(self, services=None, optimization_level=2):
         """Initialize with services (dependency injection) and optimization level."""
-        super().__init__(optimization_level)
-        self.services = services
+        super().__init__(services=services, optimization_level=optimization_level)
 
     def can_convert(self, element):
         return self.get_element_tag(element) == 'circle'
@@ -69,8 +67,7 @@ class EllipseConverter(NumPyShapeConverter):
 
     def __init__(self, services=None, optimization_level=2):
         """Initialize with services (dependency injection) and optimization level."""
-        super().__init__(optimization_level)
-        self.services = services
+        super().__init__(services=services, optimization_level=optimization_level)
 
     def can_convert(self, element):
         return self.get_element_tag(element) == 'ellipse'
@@ -81,8 +78,7 @@ class PolygonConverter(NumPyShapeConverter):
 
     def __init__(self, services=None, optimization_level=2):
         """Initialize with services (dependency injection) and optimization level."""
-        super().__init__(optimization_level)
-        self.services = services
+        super().__init__(services=services, optimization_level=optimization_level)
 
     def can_convert(self, element):
         tag = self.get_element_tag(element)
@@ -94,8 +90,7 @@ class LineConverter(NumPyShapeConverter):
 
     def __init__(self, services=None, optimization_level=2):
         """Initialize with services (dependency injection) and optimization level."""
-        super().__init__(optimization_level)
-        self.services = services
+        super().__init__(services=services, optimization_level=optimization_level)
 
     def can_convert(self, element):
         return self.get_element_tag(element) == 'line'

--- a/tests/unit/converters/shapes/test_numpy_converter_registry.py
+++ b/tests/unit/converters/shapes/test_numpy_converter_registry.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.converters.base import ConverterRegistry
+from src.converters.shapes import (
+    CircleConverter,
+    EllipseConverter,
+    LineConverter,
+    PolygonConverter,
+    RectangleConverter,
+)
+from src.services.conversion_services import ConversionServices
+
+
+@pytest.mark.parametrize(
+    "converter_cls",
+    [
+        RectangleConverter,
+        CircleConverter,
+        EllipseConverter,
+        PolygonConverter,
+        LineConverter,
+    ],
+)
+def test_numpy_converters_register_with_registry(converter_cls):
+    services = ConversionServices.create_default()
+    registry = ConverterRegistry(services=services)
+
+    registry.register_class(converter_cls)
+
+    registered_converter = next(
+        (converter for converter in registry.converters if isinstance(converter, converter_cls)),
+        None,
+    )
+
+    assert registered_converter is not None
+    assert registered_converter.services is services


### PR DESCRIPTION
## Summary
- inject the ConversionServices dependency into the NumPyShapeConverter and related helper factories
- update the shape converter adapters to forward services during initialization
- add a ConverterRegistry smoke test to confirm NumPy shape converters build with injected services

## Testing
- pytest tests/unit/converters/shapes/test_numpy_converter_registry.py *(fails: missing required plugins in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c8e2a3c83209349a17e5fb65afe