### PR TITLE
Ensure text converter fallback passes services

### DIFF
--- a/src/converters/text.py
+++ b/src/converters/text.py
@@ -62,7 +62,9 @@ class TextConverter(BaseConverter):
         if self.enable_text_to_path_fallback:
             try:
                 from .text_to_path import TextToPathConverter
-                self._text_to_path_converter = TextToPathConverter()
+                self._text_to_path_converter = TextToPathConverter(
+                    services=self.services
+                )
                 logger.info("Text-to-path fallback enabled")
             except ImportError as e:
                 logger.warning(f"Could not enable text-to-path fallback: {e}")

--- a/src/converters/text_to_path.py
+++ b/src/converters/text_to_path.py
@@ -13,13 +13,17 @@ Key Features:
 """
 
 from lxml import etree as ET
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional, Tuple, TYPE_CHECKING
 import logging
 import re
 
 from .base import BaseConverter, ConversionContext
 from .font_metrics import FontMetricsAnalyzer, FontMetrics
 from .path_generator import PathGenerator
+
+
+if TYPE_CHECKING:
+    from ..services.conversion_services import ConversionServices
 
 
 logger = logging.getLogger(__name__)
@@ -45,14 +49,17 @@ class TextToPathConverter(BaseConverter):
         'max_cache_size': 256
     }
     
-    def __init__(self, config: Optional[Dict[str, Any]] = None):
+    def __init__(self,
+                 config: Optional[Dict[str, Any]] = None,
+                 services: Optional['ConversionServices'] = None):
         """
         Initialize TextToPathConverter with configuration.
-        
+
         Args:
             config: Configuration dictionary for converter behavior
+            services: Optional ConversionServices container for dependency injection
         """
-        super().__init__()
+        super().__init__(services)
         self.config = {**self.DEFAULT_CONFIG, **(config or {})}
         
         # Initialize core components

--- a/tests/unit/converters/test_converter_dependency_injection_comprehensive.py
+++ b/tests/unit/converters/test_converter_dependency_injection_comprehensive.py
@@ -145,6 +145,20 @@ class TestTextConverterDependencyInjection:
         assert converter.can_convert(element) is True
         assert 'text' in converter.supported_elements
 
+    def test_text_converter_text_to_path_fallback_initialization(self, mock_conversion_services):
+        """Ensure enabling text-to-path fallback initializes converter without errors."""
+        from src.converters.text import TextConverter
+
+        converter = TextConverter(
+            services=mock_conversion_services,
+            enable_font_embedding=False,
+            enable_text_to_path_fallback=True,
+        )
+
+        assert converter.enable_text_to_path_fallback is True
+        assert converter._text_to_path_converter is not None
+        assert converter._text_to_path_converter.services is mock_conversion_services
+
 
 class TestPathConverterDependencyInjection:
     """Test PathConverter with dependency injection patterns."""


### PR DESCRIPTION
## Summary
- allow `TextToPathConverter` to accept optional services and hand them to `BaseConverter`
- make the text converter pass its services into the text-to-path fallback helper
- cover the regression with a dependency-injection test exercising the fallback path

## Testing
- `pytest tests/unit/converters/test_converter_dependency_injection_comprehensive.py::TestTextConverterDependencyInjection::test_text_converter_text_to_path_fallback_initialization` *(fails: Missing required plugins: pytest-benchmark>=4.0.0, pytest-html>=3.2.0, pytest-mock>=3.10.0, pytest-xdist>=3.0.0)*
- `pip install pytest-benchmark pytest-html pytest-mock pytest-xdist` *(fails: ProxyError preventing package download)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c95608c8320910a2389c5cec899